### PR TITLE
Add `MonadReader` instances for `StateRefT` and `WriterRefT`

### DIFF
--- a/monad-unlift-ref/ChangeLog.md
+++ b/monad-unlift-ref/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+* Add `MonadReader` instance for `StateRefT`
+* Add `MonadReader` instance for `WriterRefT`
+
 ## 0.2.0
 
 * Split out monad-unlift-ref

--- a/monad-unlift-ref/Control/Monad/Trans/State/Ref.hs
+++ b/monad-unlift-ref/Control/Monad/Trans/State/Ref.hs
@@ -22,6 +22,7 @@ import           Control.Applicative         (Applicative (..))
 import           Control.Monad.Catch         (MonadCatch (..), MonadMask (..),
                                               MonadThrow (..))
 import           Control.Monad.IO.Class      (MonadIO (..))
+import           Control.Monad.Reader.Class  (MonadReader (..))
 import           Control.Monad.State.Class
 import           Control.Monad.Trans.Control (defaultLiftBaseWith,
                                               defaultRestoreM)
@@ -115,6 +116,14 @@ instance ( MCState (ref s) ~ PrimState b
     {-# INLINE get #-}
     put x = seq x $ StateRefT $ liftBase . (`writeRef` x)
     {-# INLINE put #-}
+
+instance MonadReader r m => MonadReader r (StateRefT ref s m) where
+    ask = StateRefT $ const ask
+    {-# INLINE ask #-}
+    local f m = StateRefT $ local f . unStateRefT m
+    {-# INLINE local #-}
+    reader = StateRefT . const . reader
+    {-# INLINE reader #-}
 
 instance MonadTrans (StateRefT ref s) where
     lift = StateRefT . const

--- a/monad-unlift-ref/Control/Monad/Trans/State/Ref.hs
+++ b/monad-unlift-ref/Control/Monad/Trans/State/Ref.hs
@@ -117,6 +117,9 @@ instance ( MCState (ref s) ~ PrimState b
     put x = seq x $ StateRefT $ liftBase . (`writeRef` x)
     {-# INLINE put #-}
 
+-- |
+--
+-- Since 0.3.0
 instance MonadReader r m => MonadReader r (StateRefT ref s m) where
     ask = StateRefT $ const ask
     {-# INLINE ask #-}

--- a/monad-unlift-ref/Control/Monad/Trans/Writer/Ref.hs
+++ b/monad-unlift-ref/Control/Monad/Trans/Writer/Ref.hs
@@ -136,6 +136,9 @@ instance ( MCState (ref w) ~ PrimState b
         return a
     {-# INLINEABLE pass #-}
 
+-- |
+--
+-- Since 0.3.0
 instance MonadReader r m => MonadReader r (WriterRefT ref w m) where
     ask = WriterRefT $ const ask
     {-# INLINE ask #-}

--- a/monad-unlift-ref/Control/Monad/Trans/Writer/Ref.hs
+++ b/monad-unlift-ref/Control/Monad/Trans/Writer/Ref.hs
@@ -27,6 +27,7 @@ import           Control.Applicative         (Applicative (..))
 import           Control.Monad.Catch         (MonadCatch (..), MonadMask (..),
                                               MonadThrow (..))
 import           Control.Monad.IO.Class      (MonadIO (..))
+import           Control.Monad.Reader.Class  (MonadReader (..))
 import           Control.Monad.Trans.Control (defaultLiftBaseWith,
                                               defaultRestoreM)
 import           Control.Monad.Trans.Unlift
@@ -134,6 +135,14 @@ instance ( MCState (ref w) ~ PrimState b
         liftBase $ modifyRef' ref g
         return a
     {-# INLINEABLE pass #-}
+
+instance MonadReader r m => MonadReader r (WriterRefT ref w m) where
+    ask = WriterRefT $ const ask
+    {-# INLINE ask #-}
+    local f m = WriterRefT $ local f . unWriterRefT m
+    {-# INLINE local #-}
+    reader = WriterRefT . const . reader
+    {-# INLINE reader #-}
 
 instance MonadTrans (WriterRefT ref w) where
     lift = WriterRefT . const

--- a/monad-unlift-ref/monad-unlift-ref.cabal
+++ b/monad-unlift-ref/monad-unlift-ref.cabal
@@ -1,5 +1,5 @@
 name:                monad-unlift-ref
-version:             0.2.0
+version:             0.3.0
 synopsis:            Typeclasses for representing monad transformer unlifting
 description:         See README.md
 homepage:            https://github.com/fpco/monad-unlift


### PR DESCRIPTION
Fixes fpco/monad-unlift#7.

See: https://github.com/fpco/monad-unlift/issues/7